### PR TITLE
Deliver configuration to providers with links

### DIFF
--- a/crates/core/src/link.rs
+++ b/crates/core/src/link.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     wit::{deserialize_wit_map, serialize_wit_map, WitMap},
-    ComponentId, KnownConfigName, LatticeTarget, WitInterface, WitNamespace, WitPackage,
+    ComponentId, LatticeTarget, WitInterface, WitNamespace, WitPackage,
 };
 
 /// Name of a link on the wasmCloud lattice
@@ -41,7 +41,7 @@ pub struct LinkDefinition {
 /// interface. An [`InterfaceLinkDefinition`] connects one component's import to another
 /// component's export, specifying the configuration each component needs in order to execute
 /// the request, and represents an operator's intent to allow the source to invoke the target.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize, Hash)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub struct InterfaceLinkDefinition {
     /// Source identifier for the link
     pub source_id: ComponentId,
@@ -56,26 +56,12 @@ pub struct InterfaceLinkDefinition {
     pub wit_package: WitPackage,
     /// WIT Interfaces to be used for the link, e.g. `readwrite`, `atomic`, etc.
     pub interfaces: Vec<WitInterface>,
-    /// List of named configurations to provide to the source upon request
+    /// The configuration to give to the source for this link
     #[serde(default)]
-    pub source_config: Vec<KnownConfigName>,
-    /// List of named configurations to provide to the target upon request
+    pub source_config: HashMap<String, String>,
+    /// The configuration to give to the target for this link
     #[serde(default)]
-    pub target_config: Vec<KnownConfigName>,
-}
-
-impl InterfaceLinkDefinition {
-    /// This function is here temporarily to allow pulling a map of configuration out of
-    /// [`InterfaceLinkDefinition`]s that are fed to providers.
-    ///
-    /// The configuration is expected to be extracted from target_config (i.e. upon initial `put_link` to the provider).
-    /// This utility function should be removed in the near future, and provider named configuration should be used.
-    pub fn extract_provider_config_values(&self) -> HashMap<&str, &str> {
-        self.target_config
-            .iter()
-            .flat_map(|v| v.split_once('='))
-            .collect::<HashMap<&str, &str>>()
-    }
+    pub target_config: HashMap<String, String>,
 }
 
 /// Helper function to provide a default link name

--- a/crates/provider-sdk/src/provider.rs
+++ b/crates/provider-sdk/src/provider.rs
@@ -497,14 +497,14 @@ where
             &ld.source_id,
             &ld.target,
             &ld.name,
-            &connection.config,
+            &ld.source_config,
         ))
     } else if ld.target == connection.provider_key {
         provider.receive_link_config_as_target((
             &ld.source_id,
             &ld.target,
             &ld.name,
-            &connection.config,
+            &ld.target_config,
         ))
     } else {
         bail!("received link put where provider was neither source nor target");
@@ -771,6 +771,8 @@ pub struct ProviderConnection {
     link_name: String,
     provider_key: String,
 
+    // TODO: Reference this field to get static config
+    #[allow(unused)]
     config: HashMap<String, String>,
 
     /// Mapping of NATS subjects to dynamic function information for incoming invocations

--- a/crates/providers/http-server/wasmcloud.toml
+++ b/crates/providers/http-server/wasmcloud.toml
@@ -1,0 +1,10 @@
+name = "HTTP Server"
+language = "rust"
+type = "provider"
+
+[rust]
+target_dir = "../"
+
+[provider]
+bin_name = "httpserver"
+vendor = "wasmCloud"


### PR DESCRIPTION
## Feature or Problem
This PR fixes a race condition in config, and actually delivers configuration to providers based on source/target config instead of the named configuration. I went ahead and modified the tests to put configuration for the HTTP server link as well.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
